### PR TITLE
update python and cuda in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.0-slim AS build
+FROM python:3.9.0-slim AS build
 
 RUN apt-get clean && \
     apt-get update -y && \
@@ -14,12 +14,12 @@ ENV PATH=/root/.local/bin:$PATH
 
 RUN pip3 install --user --upgrade pip
 RUN pip install --user cython
-RUN pip3 install --user torch==1.7.1+cu101 torchvision==0.8.2+cu101 -f https://download.pytorch.org/whl/torch_stable.html
+RUN pip3 install --user torch==1.7.1+cu110 torchvision==0.8.2+cu110 -f https://download.pytorch.org/whl/torch_stable.html
 RUN pip3 install --user -r requirements.txt
 
 COPY /code . 
 
-FROM python:3.8.0-slim
+FROM python:3.9.0-slim
 
 RUN apt-get clean && \
     apt-get update -y && \


### PR DESCRIPTION
The docker file doesn't use the latest versions of python and cuda supported by CLIP so it's not able to use the latest version of CLIP from PyPi. This was causing an error for me since some older versions of CLIP don't recognize `model.input_resolution`. The newest version of CLIP supports `image_resolution` and `input_resolution` so it should fix this issue.